### PR TITLE
[parser/ast] useの追加

### DIFF
--- a/ast/def.ts
+++ b/ast/def.ts
@@ -15,9 +15,9 @@ export class DefFunc {
 }
 
 export class FuncSignature {
-    args: {name: string, type: Type}[];
+    args: { name: string; type: Type }[];
     returnVal: Type | null;
-    constructor(args: {name: string, type: Type}[], returnVal: Type | null) {
+    constructor(args: { name: string; type: Type }[], returnVal: Type | null) {
         this.args = args;
         this.returnVal = returnVal;
     }
@@ -42,3 +42,16 @@ export class NameSpaceBlock {
         this.defs = defs;
     }
 }
+
+export class Use {
+    isRelative: boolean;
+    tree: UseList
+    constructor(isRelative: boolean, tree: UseList) {
+        this.isRelative = isRelative
+        this.tree = tree
+    }
+}
+
+export type UseList = Ident[][]
+
+

--- a/parser/parser.pegjs
+++ b/parser/parser.pegjs
@@ -1,5 +1,6 @@
 {{
     import * as Ast from "../ast/mod.ts";
+    import * as Util from "./util.ts";
 }}
 
 Source = _ def:Def|.., _ | _ { return new Ast.Source("",def) }
@@ -27,6 +28,14 @@ DefFuncArgs
 NameSpace = NameSpaceBlock / NameSpaceLine
 NameSpaceLine = "nspace" _ dot:IsDot _ ref:DotRef _ { return new Ast.NameSpaceLine(dot,ref) }
 NameSpaceBlock = "nspace" _ dot:IsDot _ ref:DotRef _ "[" _ def:Def|.., _| _ "]" _ { return new Ast.NameSpaceBlock(dot,ref, def) }
+
+Use = "use" _ ref:IsDot _ tree:UseTree { return new Ast.Use(ref, tree.intoUseList()) }
+UseTree =
+    path:DotRef _ "." _ "[" _ trees:UseTree|..,_ "," _| _ "]" {
+        return new Util.UseInternal(path, trees)
+    }
+    / path:DotRef { return new Util.UseInternal(path,null) }
+    
 
 Stmt = Expr
 

--- a/parser/parser_test.ts
+++ b/parser/parser_test.ts
@@ -66,6 +66,13 @@ Deno.test("Use", () => {
     Assert.assertEquals(expect, parse(input, { startRule: "Use" }));
 });
 
+Deno.test("Use isRelative === true", () => {
+    const expect = new Ast.Use(true, [["Test"]]);
+    const input = "use .Test";
+    // @ts-ignore: startRuleの部分により安全
+    Assert.assertEquals(expect, parse(input, { startRule: "Use" }));
+});
+
 Deno.test("CallFunc", () => {
     const expect = new Ast.CallFunc(["Test"], []);
     const input = "Test()";

--- a/parser/parser_test.ts
+++ b/parser/parser_test.ts
@@ -14,14 +14,14 @@ Deno.test("Some test", () => {
 */
 
 Deno.test("DefFunc", () => {
-    const expect = new Ast.DefFunc("Main", new Ast.FuncSignature([],null),[]);
+    const expect = new Ast.DefFunc("Main", new Ast.FuncSignature([], null), []);
     const input = "fn Main() [ ]";
     // @ts-ignore: startRuleの部分により安全
     Assert.assertEquals(expect, parse(input, { startRule: "DefFunc" }));
 });
 
 Deno.test("DefFunc with Inner", () => {
-    const expect = new Ast.DefFunc("Main", new Ast.FuncSignature([],null),[
+    const expect = new Ast.DefFunc("Main", new Ast.FuncSignature([], null), [
         new Ast.CallFunc(["Test"], []),
         new Ast.CallFunc(["Test"], []),
     ]);
@@ -31,24 +31,39 @@ Deno.test("DefFunc with Inner", () => {
 });
 
 Deno.test("NameSpaceLine", () => {
-    const expect = new Ast.NameSpaceLine(false,["A", "B", "C"]);
+    const expect = new Ast.NameSpaceLine(false, ["A", "B", "C"]);
     const input = "nspace A.B  . C";
     // @ts-ignore: startRuleの部分により安全
     Assert.assertEquals(expect, parse(input, { startRule: "NameSpaceLine" }));
 });
 
 Deno.test("NameSpaceBlock", () => {
-    const expect = new Ast.NameSpaceBlock(false,["A", "B", "C"], [new Ast.DefFunc("Test",new Ast.FuncSignature([],null),[])]) ;
+    const expect = new Ast.NameSpaceBlock(false, ["A", "B", "C"], [
+        new Ast.DefFunc("Test", new Ast.FuncSignature([], null), []),
+    ]);
     const input = "nspace A.B.C [ fn Test() [] ]";
     // @ts-ignore: startRuleの部分により安全
     Assert.assertEquals(expect, parse(input, { startRule: "NameSpace" }));
 });
 
 Deno.test("NameSpaceLine isRelative", () => {
-    const expect = new Ast.NameSpaceLine(true, ["a", "b"]) ;
+    const expect = new Ast.NameSpaceLine(true, ["a", "b"]);
     const input = "nspace .a.b";
     // @ts-ignore: startRuleの部分により安全
     Assert.assertEquals(expect, parse(input, { startRule: "NameSpace" }));
+});
+
+Deno.test("Use", () => {
+    const expect = new Ast.Use(false, [["A", "B", "C"], [
+        "A",
+        "B",
+        "D",
+        "E",
+        "F",
+    ]]);
+    const input = "use A.B.[C,D.E.F]";
+    // @ts-ignore: startRuleの部分により安全
+    Assert.assertEquals(expect, parse(input, { startRule: "Use" }));
 });
 
 Deno.test("CallFunc", () => {

--- a/parser/util.ts
+++ b/parser/util.ts
@@ -1,0 +1,25 @@
+import { Ident, UseList } from "../ast/mod.ts";
+
+export class UseInternal {
+    path: Ident[];
+    treeList: UseInternal[] | null;
+    constructor(path: Ident[], treeList: UseInternal[] | null) {
+        this.path = path
+        this.treeList = treeList
+    }
+
+    intoUseList(): UseList {
+        if (this.treeList === null) {
+            return [this.path]
+        } else {
+            const list: Ident[][] = []
+            for (const item of this.treeList) {
+                const itemList = item.intoUseList()
+                for (const item2 of itemList) {
+                    list.push(this.path.concat(item2))
+                }
+            }
+            return list
+        }
+    }
+}


### PR DESCRIPTION
use A.B や use A.B.[C,D.E]の追加
as Aなどの追加も?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

申し訳ございません。指示に従って情報を整理し、50-100ワード以内にまとめる必要があります。それに基づいて以下の情報を提供します。

- **新機能**
	- `Use`クラスと`UseList`型を追加し、ユーザーがより柔軟にデータを扱えるようにしました。

- **リファクタリング**
	- `FuncSignature`クラスを更新して、引数の取り扱いを改善しました。

- **テスト**
	- 新しい`Use`機能に対するテストケースを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->